### PR TITLE
Include source files in packaged bundle

### DIFF
--- a/packages/chobot/.npmignore
+++ b/packages/chobot/.npmignore
@@ -2,3 +2,4 @@
 !/dist/**/*.d.ts
 !/dist/**/*.js
 !/dist/**/*.js.map
+!/src/**/*.ts


### PR DESCRIPTION
Source maps in `dist` folder reference source files in `src` folder. But since `src` folder was not included in the bundle, actually trying to load these source maps resulted in bunch of `ENOENT` errors.